### PR TITLE
toENU(lon,lat,network)

### DIFF
--- a/src/RoutingNetworks.jl
+++ b/src/RoutingNetworks.jl
@@ -24,7 +24,7 @@ export NetworkVisualizer, NodeInfo, ShowPath
 export visualize, visualInit, visualEvent, visualUpdate, visualScale, copyVisualData
 
 #tools
-export boundingBox, distanceGeo, distanceCoord, pointInsidePolygon, nRoads, nNodes
+export boundingBox, distanceGeo, distanceCoord, pointInsidePolygon, toENU, nRoads, nNodes
 
 include("network.jl")
 

--- a/src/creation/osm2network.jl
+++ b/src/creation/osm2network.jl
@@ -99,5 +99,7 @@ function osm2network(filename::AbstractString)
       end
     end
   end
-  return Network(g, nodes, roads)
+  n = Network(g, nodes, roads)
+  n.projcenter = center
+  return n
 end

--- a/src/creation/subsets.jl
+++ b/src/creation/subsets.jl
@@ -150,19 +150,3 @@ function intersections(n::Network)
     end
     return Network(g2,nodes,roads)
 end
-
-"""
-    `updateProjection`
-    updates the (x,y) projection of the nodes of the network given their latitude/longitude
-"""
-function updateProjection!(n::Network)
-    bounds = boundingBox([(n.lon,n.lat) for n in n.nodes])
-    n.projcenter = ((bounds[2]+bounds[1])/2, (bounds[4]+bounds[3])/2)
-    nodes = Array{Node}(length(n.nodes))
-    for (i,no) in enumerate(n.nodes)
-        x,y = toENU(no.lon,no.lat,center)
-        nodes[i] = Node(x,y,no.lon,no.lat)
-    end
-    n.nodes = nodes
-    n
-end

--- a/src/creation/subsets.jl
+++ b/src/creation/subsets.jl
@@ -157,7 +157,7 @@ end
 """
 function updateProjection!(n::Network)
     bounds = boundingBox([(n.lon,n.lat) for n in n.nodes])
-    center = ((bounds[2]+bounds[1])/2, (bounds[4]+bounds[3])/2)
+    n.projcenter = ((bounds[2]+bounds[1])/2, (bounds[4]+bounds[3])/2)
     nodes = Array{Node}(length(n.nodes))
     for (i,no) in enumerate(n.nodes)
         x,y = toENU(no.lon,no.lat,center)

--- a/src/network.jl
+++ b/src/network.jl
@@ -4,32 +4,45 @@
 ###################################################
 
 """
-  `Node`, represents one network node. `x` and `y` are projections of `lon` and `lat`
-  - `lon` and `lat` do not have to be defined
+`Node`, represents one network node. `x` and `y` are projections of `lon` and `lat`
+- `lon` and `lat` do not have to be defined
 """
 immutable Node
-  x::Float64
-  y::Float64
-  lon::Float32
-  lat::Float32
+    x::Float64
+    y::Float64
+    lon::Float32
+    lat::Float32
 end
 Node(x::Float64,y::Float64) = Node(x,y,0.,0.)
 
 """
-  `Road`, represents a road in the network. roadType from 1 to 8
+`Road`, represents a road in the network. roadType from 1 to 8
 """
 immutable Road
-  orig::Int
-  dest::Int
-  # Distance in meters
-  distance::Float64
-  roadType::Int
+    orig::Int
+    dest::Int
+    # Distance in meters
+    distance::Float64
+    roadType::Int
 end
 
+"""
+`Network`, represents a routing network
+"""
 type Network
-  graph::DiGraph
-  nodes::Vector{Node}
-  roads::Dict{Tuple{Int,Int},Road}
+    "Graph of network"
+    graph::DiGraph
+    "Nodes information"
+    nodes::Vector{Node}
+    "Roads information"
+    roads::Dict{Tuple{Int,Int},Road}
+    "Center coordinates for ENU projection (only defined if used)"
+    projcenter::Tuple{Float32,Float32}
+
+    function Network(graph::DiGraph, nodes::Vector{Node}, roads::Dict{Tuple{Int,Int},Road})
+        n = new()
+        n.graph = graph; n.nodes = nodes; n.roads = roads;
+    end
 end
 
 function Network(nodes::Vector{Node}, roads::Dict{Tuple{Int,Int},Road})
@@ -45,10 +58,10 @@ function Base.show(io::IO, n::Network)
 end
 
 """
-    `nRoads`: returns number of roads in network (in both directions)
+`nRoads`: returns number of roads in network (in both directions)
 """
 nRoads(n::Network) = ne(n.graph)
 """
-    `nNodes`: returns number of nodes in network
+`nNodes`: returns number of nodes in network
 """
 nNodes(n::Network) = nv(n.graph)

--- a/src/network.jl
+++ b/src/network.jl
@@ -42,6 +42,7 @@ type Network
     function Network(graph::DiGraph, nodes::Vector{Node}, roads::Dict{Tuple{Int,Int},Road})
         n = new()
         n.graph = graph; n.nodes = nodes; n.roads = roads;
+        return n
     end
 end
 

--- a/src/tools/geometry.jl
+++ b/src/tools/geometry.jl
@@ -82,7 +82,7 @@ function updateProjection!(n::Network)
     n.projcenter = ((bounds[2]+bounds[1])/2, (bounds[4]+bounds[3])/2)
     nodes = Array{Node}(length(n.nodes))
     for (i,no) in enumerate(n.nodes)
-        x,y = toENU(no.lon,no.lat,center)
+        x,y = toENU(no.lon,no.lat,n.projcenter)
         nodes[i] = Node(x,y,no.lon,no.lat)
     end
     n.nodes = nodes


### PR DESCRIPTION
toENU will project lonlat coordinates in the network referential. 
Breaking change! => change the Network type, so old JLD Network files will become obsolete.
