### PR TITLE
Modified NetworkVisualizer

### DIFF
--- a/src/creation/rect.jl
+++ b/src/creation/rect.jl
@@ -32,7 +32,7 @@ function rectNetwork(width::Int = 5, height::Int = 10; distX::Float64=200., dist
             n1 = coordToLoc(i,j); n2 = coordToLoc(i+1,j)
             dist = distanceCoord(nodes[n1],nodes[n2])
             roads[(n1,n2)] = Road(n1,n2,dist, 5)
-            roads[(n2,n1)] = Road(n1,n2,dist, 5)
+            roads[(n2,n1)] = Road(n2,n1,dist, 5)
         end
 
         #Horizontal roads
@@ -40,7 +40,7 @@ function rectNetwork(width::Int = 5, height::Int = 10; distX::Float64=200., dist
             n1 = coordToLoc(i,j); n2 = coordToLoc(i,j+1)
             dist = distanceCoord(nodes[n1],nodes[n2])
             roads[(n1,n2)] = Road(n1,n2,dist, 5)
-            roads[(n2,n1)] = Road(n1,n2,dist, 5)
+            roads[(n2,n1)] = Road(n2,n1,dist, 5)
         end
         return Network(nodes, roads)
 end

--- a/src/visualization/nodeinfo.jl
+++ b/src/visualization/nodeinfo.jl
@@ -13,6 +13,7 @@ type NodeInfo <: NetworkVisualizer
     nodes::Vector{CircleShape}
     roads::Dict{Tuple{Int,Int},Line}
     nodeRadius::Float64
+    nodesToView::Vector{Node}
 
     "node positions KD-tree"
     tree::KDTree
@@ -32,6 +33,7 @@ type NodeInfo <: NetworkVisualizer
         obj.network = n
         obj.tree = KDTree(dataPos)
         obj.selectedNode = 1
+        obj.nodesToView = n.nodes
         return obj
     end
 end

--- a/src/visualization/showpath.jl
+++ b/src/visualization/showpath.jl
@@ -14,6 +14,7 @@ type ShowPath <: NetworkVisualizer
     nodes::Vector{CircleShape}
     roads::Dict{Tuple{Int,Int},Line}
     nodeRadius::Float64
+    nodesToView::Vector{Node}
 
 
     "path to show"
@@ -27,6 +28,7 @@ type ShowPath <: NetworkVisualizer
         obj.network  = n
         obj.path     = path
         obj.nodeinfo = NodeInfo(n)
+        obj.nodesToView = n.nodes[path]
         return obj
     end
 end
@@ -39,6 +41,24 @@ function visualInit(v::ShowPath)
         line = v.roads[r.orig,r.dest]
         set_fillcolor(line,Color(255,0,0))
         set_thickness(line, get_thickness(line)*2)
+    end
+end
+
+function visualScale(v::ShowPath)
+    # BEGIN NOTE
+    # should visuals be given to nodeinfo again ? I'm not sure what copyVisualData does but it doesn't look like it should be called again
+    # END NOTE
+    # change the path
+    for r in pathRoads(v.network, v.path)
+        line = v.roads[r.orig, r.dest]
+        set_thickness(line, get_thickness(line)*2)
+    end
+end
+
+function visualEndUpdate(v::ShowPath, frameTime::Float64)
+    for road in pathRoads(v.network, v.path)
+        line = v.roads[road.orig, road.dest]
+        draw(v.window,line)
     end
 end
 

--- a/src/visualization/showpath.jl
+++ b/src/visualization/showpath.jl
@@ -45,9 +45,6 @@ function visualInit(v::ShowPath)
 end
 
 function visualScale(v::ShowPath)
-    # BEGIN NOTE
-    # should visuals be given to nodeinfo again ? I'm not sure what copyVisualData does but it doesn't look like it should be called again
-    # END NOTE
     # change the path
     for r in pathRoads(v.network, v.path)
         line = v.roads[r.orig, r.dest]

--- a/src/visualization/visualize.jl
+++ b/src/visualization/visualize.jl
@@ -12,6 +12,7 @@
     - attribute `nodes::Vector{CircleShape}`
     - attribute `roads::Dict{Tuple{Int,Int},Line}`
     - attribute `nodeRadius::Float64` (to scale things)
+    - attribute `nodesToView::Vector{Node}` nodes that will be in initial view
 
     can implement
     - method `visualInit` => initialize things
@@ -96,7 +97,7 @@ function visualize(v::NetworkVisualizer)
     event = Event()
 
     # Set up the initial view
-    minX, maxX, minY, maxY = boundingBox(Tuple{Float64,Float64}[(n.x,n.y) for n in v.network.nodes])
+    minX, maxX, minY, maxY = boundingBox(Tuple{Float64,Float64}[(n.x,n.y) for n in v.nodesToView])
     # Do the Y-axis transformation
     minY, maxY = -maxY, -minY
     networkLength = max(maxX-minX, maxY-minY)


### PR DESCRIPTION
Added nodesToView field and made it so that initial window only displays these nodes. This allows us to start with a zoomed-in view, which is really useful when you want to have the exact same zoomed-in view at every iteration of a method for example.

All NetworkVisualizers had to be modified because of a change in visualize, but it's a really small internal change and it shouldn't break anything (unless you saved NetworkVisualizers which I don't think you did).

I also fixed a bug in ShowPath: at the beginning, the edges in the path were twice as thick as other edges, but that stopped being the case after the edge thicknesses were changed using "A" or "S". This is now fixed.
